### PR TITLE
Revert "Insert the tagmanager snippet  in index.ejs"

### DIFF
--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -36,13 +36,7 @@
 
         <link href='https://api.mapbox.com/mapbox.js/v2.2.3/mapbox.css' rel='stylesheet' />
 
-<!-- Google Tag Manager -->
-        <script>
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-K62MK9D');
-        </script>
-<!-- End Google Tag Manager -->
-
-<!-- Google Code for Tracciamento sito Conversion Page -->
+        <!-- Google Code for Tracciamento sito Conversion Page -->
         <script type="text/javascript">
         /* <![CDATA[ */
         var google_conversion_id = 951680517;
@@ -58,7 +52,7 @@
         </div>
         </noscript>
 
-<!-- Google Analytics: change UA-XXXXX-X to be your site's ID -->
+        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID -->
         <script>
             (function(i, s, o, g, r, a, m) {
                 i['GoogleAnalyticsObject'] = r;
@@ -79,11 +73,6 @@
     </head>
 
     <body ng-app="riplive">
-<!-- Google Tag Manager (noscript) -->
-    <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K62MK9D"height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
-<!-- End Google Tag Manager (noscript) -->
         <main id="container">
             <div id="inner-wrapper" class="container-fluid">
                 <aside id="side-menu" class="menu-closed" ng-include src="'js/app/templates/side-menu.html'" toggle-side-menu></aside>


### PR DESCRIPTION
Reverts ripliveit/riplive.it#67

after this change, AdGrants performance fall-down whitout sense. Maybe there is as conflict between tagmanager and analytics settings